### PR TITLE
fix: Remove support for odoo 9.0 and 10.0 and fix support for 11.0 and 12.0

### DIFF
--- a/odooghost/config.py
+++ b/odooghost/config.py
@@ -299,7 +299,7 @@ class OdooStackConfig(BaseModel):
         Returns:
             float: Odoo version
         """
-        if v not in (9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0):
+        if v not in (11.0, 12.0, 13.0, 14.0, 15.0, 16.0):
             raise ValueError(f"Unsuported Odoo version {v}")
         return v
 

--- a/odooghost/templates/Dockerfile.j2
+++ b/odooghost/templates/Dockerfile.j2
@@ -6,6 +6,14 @@ USER odoo
 
 {% if dependencies.apt %}
 USER root
+# Fix for 11.0 Odoo_Version
+{% if odoo_version <= 11.0 %}
+USER root
+RUN sed -i -e 's/deb.debian.org/archive.debian.org/g' \
+    -e 's|security.debian.org|archive.debian.org/|g' \
+    -e '/stretch-updates/d' /etc/apt/sources.list
+RUN rm -rf /etc/apt/sources.list.d/backports.list
+{% endif %}
 RUN apt-get update && apt-get install -y --no-install-recommends \
     {% for dep in dependencies.apt %}
 {{ dep }} \


### PR DESCRIPTION
fix(config.py): remove unsupported Odoo version 9.0 and 10.0 from th list of supported versions in the get_odoo_version method

fix(Dockerfile.j2): add a fix for Odoo version 11.0 and 12.0 to update the package sources to use archive.debian.org instead of deb.debian.org and remove the stretch-updates source