### PR TITLE
feat(cli): Add autocompletion support

### DIFF
--- a/odooghost/cli/stack/config.py
+++ b/odooghost/cli/stack/config.py
@@ -6,7 +6,7 @@ from loguru import logger
 from pydantic import ValidationError
 
 from odooghost.stack import Stack
-from odooghost.utils.autocomplete import ac_yml_files
+from odooghost.utils.autocomplete import ac_stack_configs
 
 cli = typer.Typer(no_args_is_help=True)
 
@@ -22,7 +22,7 @@ def check(
             readable=True,
             resolve_path=True,
             exists=True,
-            autocompletion=ac_yml_files,
+            autocompletion=ac_stack_configs,
         ),
     ]
 ) -> None:

--- a/odooghost/cli/stack/config.py
+++ b/odooghost/cli/stack/config.py
@@ -6,6 +6,7 @@ from loguru import logger
 from pydantic import ValidationError
 
 from odooghost.stack import Stack
+from odooghost.utils.autocomplete import ac_yml_files
 
 cli = typer.Typer(no_args_is_help=True)
 
@@ -21,6 +22,7 @@ def check(
             readable=True,
             resolve_path=True,
             exists=True,
+            autocompletion=ac_yml_files,
         ),
     ]
 ) -> None:

--- a/odooghost/cli/stack/data.py
+++ b/odooghost/cli/stack/data.py
@@ -8,6 +8,7 @@ from odooghost import exceptions
 from odooghost.services import db, odoo
 from odooghost.stack import Stack
 from odooghost.utils import exec, misc
+from odooghost.utils.autocomplete import ac_stacks_lists
 
 if t.TYPE_CHECKING:
     from odooghost.container import Container
@@ -19,7 +20,9 @@ cli = typer.Typer(no_args_is_help=True)
 def dump(
     stack_name: t.Annotated[
         str,
-        typer.Argument(..., help="Stack name", show_default=False),
+        typer.Argument(
+            ..., help="Stack name", show_default=False, autocompletion=ac_stacks_lists
+        ),
     ],
     dbname: t.Annotated[str, typer.Argument(help="Database name", show_default=False)],
     dest: t.Annotated[
@@ -98,7 +101,7 @@ def dump(
 def restore(
     stack_name: t.Annotated[
         str,
-        typer.Argument(..., help="Stack name"),
+        typer.Argument(..., help="Stack name", autocompletion=ac_stacks_lists),
     ],
     dbname: t.Annotated[str, typer.Argument(help="Database name")],
     dump_path: t.Annotated[
@@ -234,7 +237,7 @@ def restore(
 def drop(
     stack_name: t.Annotated[
         str,
-        typer.Argument(..., help="Stack name"),
+        typer.Argument(..., help="Stack name", autocompletion=ac_stacks_lists),
     ],
     dbname: t.Annotated[str, typer.Argument(help="Database name")],
 ) -> None:

--- a/odooghost/cli/stack/root.py
+++ b/odooghost/cli/stack/root.py
@@ -10,9 +10,9 @@ from odooghost import constant, exceptions
 from odooghost.stack import Stack
 from odooghost.utils import signals
 from odooghost.utils.autocomplete import (
+    ac_stack_configs,
     ac_stacks_lists,
     ac_stacks_services,
-    ac_yml_files,
 )
 
 from .config import cli as configCLI
@@ -122,7 +122,7 @@ def update(
             readable=True,
             resolve_path=True,
             exists=True,
-            autocompletion=ac_yml_files,
+            autocompletion=ac_stack_configs,
         ),
     ],
     do_pull: t.Annotated[

--- a/odooghost/cli/stack/root.py
+++ b/odooghost/cli/stack/root.py
@@ -9,6 +9,11 @@ from loguru import logger
 from odooghost import constant, exceptions
 from odooghost.stack import Stack
 from odooghost.utils import signals
+from odooghost.utils.autocomplete import (
+    ac_stacks_lists,
+    ac_stacks_services,
+    ac_yml_files,
+)
 
 from .config import cli as configCLI
 from .data import cli as dataCLI
@@ -117,6 +122,7 @@ def update(
             readable=True,
             resolve_path=True,
             exists=True,
+            autocompletion=ac_yml_files,
         ),
     ],
     do_pull: t.Annotated[
@@ -138,7 +144,7 @@ def update(
 def start(
     stack_name: t.Annotated[
         str,
-        typer.Argument(..., help="Stack name"),
+        typer.Argument(..., help="Stack name", autocompletion=ac_stacks_lists),
     ],
     detach: t.Annotated[
         bool, typer.Option("--detach", help="Do not stream Odoo service logs")
@@ -178,7 +184,7 @@ def start(
 def stop(
     stack_name: t.Annotated[
         str,
-        typer.Argument(..., help="Stack name"),
+        typer.Argument(..., help="Stack name", autocompletion=ac_stacks_lists),
     ],
     timeout: t.Annotated[
         int, typer.Option(help="Stop timeout before sending SIGKILL")
@@ -199,7 +205,7 @@ def stop(
 def restart(
     stack_name: t.Annotated[
         str,
-        typer.Argument(..., help="Stack name"),
+        typer.Argument(..., help="Stack name", autocompletion=ac_stacks_lists),
     ],
     timeout: t.Annotated[
         int, typer.Option(help="Stop timeout before sending SIGKILL")
@@ -219,7 +225,7 @@ def restart(
 def logs(
     stack_name: t.Annotated[
         str,
-        typer.Argument(..., help="Stack name"),
+        typer.Argument(..., help="Stack name", autocompletion=ac_stacks_lists),
     ],
     follow: t.Annotated[
         bool, typer.Option("--follow", help="Follow logs stream")
@@ -255,11 +261,11 @@ def logs(
 def exec(
     stack_name: t.Annotated[
         str,
-        typer.Argument(..., help="Stack name"),
+        typer.Argument(..., help="Stack name", autocompletion=ac_stacks_lists),
     ],
     service_name: t.Annotated[
         str,
-        typer.Argument(..., help="Service name"),
+        typer.Argument(..., help="Service name", autocompletion=ac_stacks_services),
     ],
     command: t.Annotated[
         str,
@@ -321,11 +327,11 @@ def exec(
 def run(
     stack_name: t.Annotated[
         str,
-        typer.Argument(..., help="Stack name"),
+        typer.Argument(..., help="Stack name", autocompletion=ac_stacks_lists),
     ],
     service_name: t.Annotated[
         str,
-        typer.Argument(..., help="Service name"),
+        typer.Argument(..., help="Service name", autocompletion=ac_stacks_services),
     ],
     command: t.Annotated[
         str,

--- a/odooghost/constant.py
+++ b/odooghost/constant.py
@@ -17,6 +17,8 @@ IS_WINDOWS_PLATFORM = sys.platform == "win32"
 IS_DARWIN_PLARFORM = sys.platform == "darwin"
 IS_LINUX_PLATFORM = sys.platform == "linux"
 
+EXTENSIONS: list = ["yml", "yaml", "json"]
+
 
 class OpenMode(str, enum.Enum):
     local = "local"

--- a/odooghost/constant.py
+++ b/odooghost/constant.py
@@ -17,7 +17,7 @@ IS_WINDOWS_PLATFORM = sys.platform == "win32"
 IS_DARWIN_PLARFORM = sys.platform == "darwin"
 IS_LINUX_PLATFORM = sys.platform == "linux"
 
-EXTENSIONS: list = ["yml", "yaml", "json"]
+STACK_CONFIG_FILE_EXTENSIONS: list = ["yml", "yaml", "json"]
 
 
 class OpenMode(str, enum.Enum):

--- a/odooghost/exceptions.py
+++ b/odooghost/exceptions.py
@@ -22,14 +22,6 @@ class StackException(OdooGhostException):
     ...
 
 
-class ServiceException(OdooGhostException):
-    ...
-
-
-class ServiceAttributeMissing(ServiceException):
-    ...
-
-
 class StackConfigError(StackException):
     ...
 

--- a/odooghost/exceptions.py
+++ b/odooghost/exceptions.py
@@ -22,6 +22,14 @@ class StackException(OdooGhostException):
     ...
 
 
+class ServiceException(OdooGhostException):
+    ...
+
+
+class ServiceAttributeMissing(ServiceException):
+    ...
+
+
 class StackConfigError(StackException):
     ...
 

--- a/odooghost/services/base.py
+++ b/odooghost/services/base.py
@@ -27,7 +27,7 @@ class BaseService(abc.ABC):
 
     def _check_name_attribute(self):
         if not self.name:
-            raise exceptions.ServiceAttributeMissing("The attribute name is required")
+            raise RuntimeError("The attribute name is required")
 
     def _prepare_build_context(self) -> None:
         """

--- a/odooghost/services/base.py
+++ b/odooghost/services/base.py
@@ -20,10 +20,14 @@ if t.TYPE_CHECKING:
 
 
 class BaseService(abc.ABC):
-    def __init__(self, name: str, stack_config: "StackConfig") -> None:
-        self.name = name
+    def __init__(self, stack_config: "StackConfig") -> None:
         self.stack_config = stack_config
         self.stack_name = stack_config.name
+        self._check_name_attribute()
+
+    def _check_name_attribute(self):
+        if not self.name:
+            raise exceptions.ServiceAttributeMissing("The attribute name is required")
 
     def _prepare_build_context(self) -> None:
         """
@@ -396,6 +400,13 @@ class BaseService(abc.ABC):
         self.build()
         self.drop_containers()
         self.create_container()
+
+    @classmethod
+    def list(cls, only_name: bool = False) -> list:
+        all_services = cls.__subclasses__()
+        if only_name:
+            return [c.name for c in all_services]
+        return all_services
 
     @abc.abstractproperty
     def config(self) -> t.Type["StackServiceConfig"]:

--- a/odooghost/services/db.py
+++ b/odooghost/services/db.py
@@ -83,8 +83,10 @@ def restore_database(
 
 
 class DbService(BaseService):
+    name = "db"
+
     def __init__(self, stack_config: "config.StackConfig") -> None:
-        super().__init__(name="db", stack_config=stack_config)
+        super().__init__(stack_config=stack_config)
 
     def _get_environment(self) -> t.Dict[str, t.Any]:
         return dict(

--- a/odooghost/services/odoo/service.py
+++ b/odooghost/services/odoo/service.py
@@ -21,8 +21,10 @@ def get_filestore_path(dbname: str) -> str:
 
 
 class OdooService(BaseService):
+    name = "odoo"
+
     def __init__(self, stack_config: "config.StackConfig") -> None:
-        super().__init__(name="odoo", stack_config=stack_config)
+        super().__init__(stack_config=stack_config)
         self.addons = AddonsHandler(
             odoo_version=self.config.version, addons_config=self.config.addons
         )

--- a/odooghost/utils/autocomplete.py
+++ b/odooghost/utils/autocomplete.py
@@ -1,7 +1,7 @@
 import os
 from typing import Generator
 
-from odooghost.constant import EXTENSIONS
+from odooghost.constant import STACK_CONFIG_FILE_EXTENSIONS
 from odooghost.services.base import BaseService
 from odooghost.stack import Stack
 
@@ -12,11 +12,11 @@ def ac_stacks_lists(incomplete: str) -> Generator:
             yield stack.name
 
 
-def ac_yml_files(incomplete: str) -> Generator:
+def ac_stack_configs(incomplete: str) -> Generator:
     for file in os.listdir():
-        if any(file.endswith(ext) for ext in EXTENSIONS) and file.startswith(
-            incomplete
-        ):
+        if any(
+            file.endswith(ext) for ext in STACK_CONFIG_FILE_EXTENSIONS
+        ) and file.startswith(incomplete):
             yield file
 
 

--- a/odooghost/utils/autocomplete.py
+++ b/odooghost/utils/autocomplete.py
@@ -1,0 +1,26 @@
+import os
+from typing import Generator
+
+from odooghost.constant import EXTENSIONS
+from odooghost.services.base import BaseService
+from odooghost.stack import Stack
+
+
+def ac_stacks_lists(incomplete: str) -> Generator:
+    for stack in Stack.list():
+        if stack.name.lower().startswith(incomplete.lower()):
+            yield stack.name
+
+
+def ac_yml_files(incomplete: str) -> Generator:
+    for file in os.listdir():
+        if any(file.endswith(ext) for ext in EXTENSIONS) and file.startswith(
+            incomplete
+        ):
+            yield file
+
+
+def ac_stacks_services(incomplete: str) -> Generator:
+    for service in BaseService.list(only_name=True):
+        if service.startswith(incomplete) or not incomplete:
+            yield service


### PR DESCRIPTION
feat(cli): add autocompletion support for stack names in various commands
feat(cli): add autocompletion support for database dump and restore commands
feat(cli): add autocompletion support for stack service names in various commands
feat(cli): add autocompletion support for yml file names in various commands
fix(constant.py): add list of supported file extensions for autocompletion
fix(services/base.py): add check for name attribute in BaseService to prevent missing attribute error
feat(services/base.py): add list method to BaseService to get a list of all services or only their names
feat(utils/autocomplete.py): add autocompletion functions for stack names, yml file names, and stack service names