### PR TITLE
fix(web): wrong JavaScript mimetype on Windows

### DIFF
--- a/odooghost/web/application.py
+++ b/odooghost/web/application.py
@@ -1,3 +1,5 @@
+import mimetypes
+
 from starlette.applications import Starlette
 from starlette.exceptions import HTTPException
 from starlette.middleware import Middleware
@@ -10,6 +12,8 @@ from strawberry.asgi import GraphQL
 
 from odooghost import constant
 from odooghost.web.api.schema import schema
+
+mimetypes.add_type("text/javascript", ".js")
 
 
 async def not_found(request: Request, exc: HTTPException):


### PR DESCRIPTION
## Issue
On Windows (10), the command `odooghost web` doesn't work. The files are served, but the browser (Firefox) can't read them because `.js` files are typed as `text/plain` instead of `text/javascript`.

## Cause
Mimetypes are detected by Starlette.
https://github.com/encode/starlette/blob/0.33.0/starlette/responses.py#L285

Starlette uses the `guess_type()` method from `mimetypes` Python stdlib.
https://docs.python.org/3/library/mimetypes.html

The types returned by this method are not defined by Python, but by the OS. So, some differences can be found between Windows and Linux.
https://bugs.python.org/issue43975

## Resolution
The method `add_type()` can be used to override any default type with a custom value. By this way, we can force ".js" to always return "text/javascript".

Fixing only JS seems to be enough for the moment, but maybe we'll have the same issue for other types later ¯\\\_(ツ)\_/¯