### PR TITLE
feat: Adds Property to Modify APT Repositories for Archived Linux Distributions

### DIFF
--- a/odooghost/config/dependency.py
+++ b/odooghost/config/dependency.py
@@ -82,6 +82,7 @@ class DependenciesConfig(BaseModel):
     """
 
     apt: t.Optional[t.List[str]] = None
+    apt_archived: bool = False
     python: t.Optional[PythonDependenciesConfig] = None
 
     @field_validator("apt")

--- a/odooghost/templates/Dockerfile.j2
+++ b/odooghost/templates/Dockerfile.j2
@@ -8,7 +8,7 @@ USER root
 # Fix for 11.0 Odoo_Version
 {% if dependencies.apt_archived %}
 RUN sed -i -e 's/deb.debian.org/archive.debian.org/g' \
-    -e 's|security.debian.org|archive.debian.org/|g' \
+    -e 's|security.debian.org|archive.debian.org|g' \
     -e '/stretch-updates/d' /etc/apt/sources.list
 RUN rm -rf /etc/apt/sources.list.d/backports.list
 {% endif %}

--- a/odooghost/templates/Dockerfile.j2
+++ b/odooghost/templates/Dockerfile.j2
@@ -6,7 +6,7 @@ RUN chown -R odoo:odoo /etc/odoo
 {% if dependencies.apt %}
 USER root
 # Fix for 11.0 Odoo_Version
-{% if odoo_version <= 12.0 %}
+{% if dependencies.apt_archived %}
 RUN sed -i -e 's/deb.debian.org/archive.debian.org/g' \
     -e 's|security.debian.org|archive.debian.org/|g' \
     -e '/stretch-updates/d' /etc/apt/sources.list


### PR DESCRIPTION
#### Summary
This PR introduces a property to modify APT repositories when a Linux distribution reaches its end-of-life (EOL) and is transferred to archived repositories.

#### Changes
- Added `dependencies.apt_archived` property to handle APT repository modifications.

#### Context
Ensures continued package availability by redirecting APT sources to archive URLs for EOL distributions.
