### PR TITLE
chore(ci): Fix workflows to use specific poetry version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
 
       # install poetry
       - name: Install poetry
-        run: pipx install poetry
+        run: pipx install poetry==1.8.5 # TODO: update to latest version but breaking change in 2.0.0
 
       # set-up python with cache
       - name: Setup Python 3.11


### PR DESCRIPTION
Breaking change in 2.0.0

but the cause is unknown (doesn’t seem to have been found yet).

https://github.com/python-poetry/poetry/blob/main/CHANGELOG.md#200---2025-01-05