### PR TITLE
feat(dependencies): Add custom installations support in DependenciesConfig and Dockerfile

### DIFF
--- a/odooghost/config/dependency.py
+++ b/odooghost/config/dependency.py
@@ -84,6 +84,7 @@ class DependenciesConfig(BaseModel):
     apt: t.Optional[t.List[str]] = None
     apt_archived: bool = False
     python: t.Optional[PythonDependenciesConfig] = None
+    custom_installations: t.Optional[t.List[str]] = None
 
     @field_validator("apt")
     def string_to_list(cls, v: str | list) -> t.List[str]:

--- a/odooghost/templates/Dockerfile.j2
+++ b/odooghost/templates/Dockerfile.j2
@@ -19,6 +19,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 && rm -rf /var/lib/apt/lists/*
 {% endif %}
 
+{% if dependencies.custom_installations %}
+USER root
+{% for custom_command in dependencies.custom_installations %}
+RUN {{ custom_command }}
+{% endfor %}
+{% endif %}
+
 {% if dependencies.python %}
 USER root
 ENV PIP_BREAK_SYSTEM_PACKAGES=1


### PR DESCRIPTION
Add custom installations support to OdooGhost

Adds the ability to define custom installation commands directly in config.yml files. This feature allows users to: install browsers and other software with multi-step installation processes.

e.g.

```
      custom_installations:
        - "apt-get update"
        - "apt-get install -y --no-install-recommends wget ca-certificates"
        - "wget -q https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb"
        - "apt-get install -y --no-install-recommends ./google-chrome-stable_current_amd64.deb"
        - "apt-get install -y --no-install-recommends fonts-liberation xdg-utils"
        - "apt --fix-broken install -y"
        - "rm -f google-chrome-stable_current_amd64.deb"
        - "rm -rf /var/lib/apt/lists/*"
 ```
