### PR TITLE
Fix browser open URL to use mapped host port for Odoo service

### DIFF
--- a/odooghost/cli/stack/root.py
+++ b/odooghost/cli/stack/root.py
@@ -152,11 +152,7 @@ def start(
     open: t.Annotated[bool, typer.Option("--open", help="Open in browser")] = False,
     open_mode: t.Annotated[
         constant.OpenMode, typer.Option("--open-mode", help="Open mode")
-    ] = (
-        constant.OpenMode.subnet
-        if constant.IS_LINUX_PLATFORM
-        else constant.OpenMode.local
-    ),
+    ] = constant.OpenMode.local,
     tail: t.Annotated[
         int,
         typer.Option("--tail", help="Number of lines to show from the end of the logs"),
@@ -168,11 +164,11 @@ def start(
     try:
         stack = Stack.from_name(name=stack_name)
         stack.start()
-        odoo = stack.get_service(name="odoo").get_container()
+        odoo_service = stack.get_service(name="odoo")
+        odoo = odoo_service.get_container()
         if open:
-            webbrowser.open(
-                f"http://{odoo.get_subnet_port(8069) if open_mode == constant.OpenMode.subnet else odoo.get_local_port(8069)}"
-            )
+            url = f"http://{odoo.get_subnet_port(odoo_service.container_port) if open_mode == constant.OpenMode.subnet else odoo.get_local_port(odoo_service.container_port)}"
+            webbrowser.open(url)
         if not detach:
             while True:
                 try:

--- a/odooghost/container.py
+++ b/odooghost/container.py
@@ -217,7 +217,7 @@ class Container:
             return None
         port = port[0]
         host_ip, host_port = port.values()
-        if constant.IS_DARWIN_PLARFORM and host_ip == "0.0.0.0":  # nosec B104
+        if host_ip == "0.0.0.0":  # nosec B104
             host_ip = "localhost"
         return f"{host_ip}:{host_port}"
 


### PR DESCRIPTION
Ensure the `--open` flag opens the browser at the correct mapped host port (e.g., `localhost:19001`) instead of the container's internal subnet IP and port. The logic now uses the Odoo service's container port to look up the host port mapping, providing a reliable and accessible URL for local development.